### PR TITLE
feat: Adicionar suporte a variáveis de ambiente para repositório de t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 All notable changes to the Specify CLI will be documented in this file.
 
+## [0.0.18] - 2025-09-25
+
+### Added
+
+- Environment variable overrides for template source repository: `SPECIFY_TEMPLATE_REPO_OWNER` and `SPECIFY_TEMPLATE_REPO_NAME` allowing users to pull release assets from forks or custom repositories without patching the CLI.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -13,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `/clarify` command template to surface up to 5 targeted clarification questions for an existing spec and persist answers into a Clarifications section in the spec.
 - New `/analyze` command template providing a non-destructive cross-artifact discrepancy and alignment report (spec, clarifications, plan, tasks, constitution) inserted after `/tasks` and before `/implement`.
-	- Note: Constitution rules are explicitly treated as non-negotiable; any conflict is a CRITICAL finding requiring artifact remediation, not weakening of principles.
+  - Note: Constitution rules are explicitly treated as non-negotiable; any conflict is a CRITICAL finding requiring artifact remediation, not weakening of principles.
 
 ## [0.0.16] - 2025-09-22
 
@@ -89,7 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated command instructions in the CLI.
 - Cleaned up the code to not render agent-specific information when it's generic.
-
 
 ## [0.0.6] - 2025-09-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.0.17"
+version = "0.0.18"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -619,8 +619,18 @@ def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
 
 
 def download_template_from_github(ai_assistant: str, download_dir: Path, *, script_type: str = "sh", verbose: bool = True, show_progress: bool = True, client: httpx.Client = None, debug: bool = False, github_token: str = None, use_cache: bool = True) -> Tuple[Path, dict]:
-    repo_owner = "cmacguide"
-    repo_name = "cmac-agentic-spec"
+    """Download latest template release asset for given AI assistant.
+
+    Environment overrides:
+      SPECIFY_TEMPLATE_REPO_OWNER -> owner (default: github)
+      SPECIFY_TEMPLATE_REPO_NAME  -> name  (default: spec-kit)
+
+    These allow testing/fork usage without patching the codebase.
+    """
+    repo_owner = (os.getenv("SPECIFY_TEMPLATE_REPO_OWNER") or "github").strip() or "github"
+    repo_name = (os.getenv("SPECIFY_TEMPLATE_REPO_NAME") or "spec-kit").strip() or "spec-kit"
+    if verbose:
+        console.print(f"[dim]Template source:[/dim] {repo_owner}/{repo_name}")
     if client is None:
         client = httpx.Client(verify=ssl_context)
     


### PR DESCRIPTION

This pull request introduces a new feature to the Specify CLI, allowing users to override the default template source repository via environment variables. This enhancement makes it easier to pull release assets from forks or custom repositories without modifying the CLI code directly. The version is also bumped to `0.0.18` to reflect this update.

**Template source override feature:**

* Added support for environment variables `SPECIFY_TEMPLATE_REPO_OWNER` and `SPECIFY_TEMPLATE_REPO_NAME` in the `download_template_from_github` function, enabling users to specify custom template repositories. The default values are now `"github"` for the owner and `"spec-kit"` for the repository, with a console message indicating the source.

**Release and documentation updates:**

* Updated the version in `pyproject.toml` from `0.0.17` to `0.0.18` to reflect the new feature.
* Added a changelog entry for version `0.0.18` in `CHANGELOG.md`, describing the new environment variable override feature.