### PR TITLE
feat: Atualizar caminho do template de especificação para nova estrut…

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -80,7 +80,7 @@ fi
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$REPO_ROOT/templates/spec-template.md"
+TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
 SPEC_FILE="$FEATURE_DIR/spec.md"
 if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
 

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -89,7 +89,7 @@ if ($hasGit) {
 $featureDir = Join-Path $specsDir $branchName
 New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
 
-$template = Join-Path $repoRoot 'templates/spec-template.md'
+$template = Join-Path $repoRoot '.specify/templates/spec-template.md'
 $specFile = Join-Path $featureDir 'spec.md'
 if (Test-Path $template) { 
     Copy-Item $template $specFile -Force 


### PR DESCRIPTION
This pull request updates the template path used when creating new feature specifications in both the Bash and PowerShell scripts. The scripts now reference the template from the `.specify/templates` directory instead of the previous `templates` location.

**Script updates for template path:**

* In `scripts/bash/create-new-feature.sh`, the `spec-template.md` template path was changed to `.specify/templates/spec-template.md` to match the new directory structure.
* In `scripts/powershell/create-new-feature.ps1`, the template path for `spec-template.md` was similarly updated to `.specify/templates/spec-template.md`.…ura de diretórios