### PR TITLE
feat: Adicionar script para carregar módulo de Integração da Knowledg…

### DIFF
--- a/scripts/bash/include-kb.sh
+++ b/scripts/bash/include-kb.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Helper para carregar o módulo de Integração da Knowledge Base
+# Funciona tanto no repo de desenvolvimento (scripts/...) quanto no pacote (.specify/scripts/...)
+
+set -euo pipefail
+
+KB_CANDIDATES=(
+  ".specify/scripts/bash/knowledge-base-integration.sh"
+  "scripts/bash/knowledge-base-integration.sh"
+)
+
+FOUND=""
+for kb_path in "${KB_CANDIDATES[@]}"; do
+  if [[ -f "$kb_path" ]]; then
+    # shellcheck source=/dev/null
+    source "$kb_path"
+    FOUND="$kb_path"
+    export SPECIFY_KB_MODULE="$kb_path"
+    break
+  fi
+done
+
+if [[ -z "$FOUND" ]]; then
+  echo "[specify] ERROR: Não encontrei knowledge-base-integration.sh nos caminhos esperados: ${KB_CANDIDATES[*]}" >&2
+  # Permite funcionar mesmo se script for 'source' ou executado diretamente
+  return 1 2>/dev/null || exit 1
+fi
+
+# Verificação básica das funções esperadas
+for fn in query_knowledge_base get_applicable_principles generate_compliance_report; do
+  if ! declare -f "$fn" >/dev/null 2>&1; then
+    echo "[specify] ERROR: Função obrigatória ausente após source: $fn" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+done
+
+export SPECIFY_KB_LOADED=1

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -17,10 +17,11 @@ Given the implementation details provided as an argument, do this:
 
 **CRITICAL**: Before proceeding with planning, MUST execute KB integration for architectural validation:
 
-1. **Source KB Integration Module**:
+1. **Source KB Integration Module (robusto)**:
 
    ```bash
-   source scripts/bash/knowledge-base-integration.sh
+   # Tenta .specify/scripts/ (pacote) ou scripts/ (dev)
+   source scripts/bash/include-kb.sh
    ```
 
 2. **Query KB for Planning Context**:


### PR DESCRIPTION
This pull request introduces a more robust approach for loading the Knowledge Base integration in bash scripts and updates documentation to reflect this change. The most important changes are:

**Knowledge Base Integration Improvements:**

* Added a new helper script `scripts/bash/include-kb.sh` that automatically locates and sources the `knowledge-base-integration.sh` module from either the package or development paths, sets environment variables, and validates required functions are present.

**Documentation Update:**

* Updated the planning command template in `templates/commands/plan.md` to instruct users to source the new `include-kb.sh` helper instead of directly sourcing `knowledge-base-integration.sh`, improving reliability and portability.